### PR TITLE
fix(dev-tools): add babel plugin

### DIFF
--- a/packages/parrot-devtools/.babelrc
+++ b/packages/parrot-devtools/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["amex"]
+  "presets": ["amex"],
+  "plugins": ["@babel/plugin-transform-runtime"]
 }

--- a/packages/parrot-devtools/package-lock.json
+++ b/packages/parrot-devtools/package-lock.json
@@ -920,6 +920,12 @@
 				"@babel/types": "^7.7.4"
 			}
 		},
+		"@babel/helper-validator-identifier": {
+			"version": "7.9.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
+			"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==",
+			"dev": true
+		},
 		"@babel/helper-wrap-function": {
 			"version": "7.7.4",
 			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.7.4.tgz",
@@ -1417,6 +1423,46 @@
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-runtime": {
+			"version": "7.9.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.9.6.tgz",
+			"integrity": "sha512-qcmiECD0mYOjOIt8YHNsAP1SxPooC/rDmfmiSK9BNY72EitdSc7l44WTEklaWuFtbOEBjNhWWyph/kOImbNJ4w==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-imports": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"resolve": "^1.8.1",
+				"semver": "^5.5.1"
+			},
+			"dependencies": {
+				"@babel/helper-module-imports": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
+					"integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
+					"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.9.6",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.6.tgz",
+					"integrity": "sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.9.5",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/plugin-transform-shorthand-properties": {

--- a/packages/parrot-devtools/package.json
+++ b/packages/parrot-devtools/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.7.7",
+    "@babel/plugin-transform-runtime": "^7.9.6",
     "archiver": "^2.1.1",
     "babel-loader": "^8.0.6",
     "babel-preset-amex": "^3.3.0",


### PR DESCRIPTION
add @babel/plugin-transform-runtime to fix `ReferenceError: regeneratorRuntime is not defined`. This error was caused by `await` not being transpiled.